### PR TITLE
🐛 Fix of potential Cross-site Scripting (XSS) vulnerabilities in Jinja2 templates.

### DIFF
--- a/cover_agent/PromptBuilder.py
+++ b/cover_agent/PromptBuilder.py
@@ -1,7 +1,6 @@
 import logging
-
-from jinja2 import Environment, StrictUndefined
-from cover_agent.settings.config_loader import get_settings
+from jinja2 import Environment, StrictUndefined, select_autoescape
+from coverage_ai.settings.config_loader import get_settings
 
 MAX_TESTS_PER_RUN = 4
 
@@ -134,7 +133,9 @@ class PromptBuilder:
             "language": self.language,
             "max_tests": MAX_TESTS_PER_RUN,
         }
-        environment = Environment(undefined=StrictUndefined)
+        environment = Environment(
+            undefined=StrictUndefined, autoescape=select_autoescape(['html', 'xml'])
+        )
         try:
             system_prompt = environment.from_string(
                 get_settings().test_generation_prompt.system

--- a/cover_agent/PromptBuilder.py
+++ b/cover_agent/PromptBuilder.py
@@ -1,4 +1,5 @@
 import logging
+
 from jinja2 import Environment, StrictUndefined, select_autoescape
 from coverage_ai.settings.config_loader import get_settings
 


### PR DESCRIPTION
### **User description**

Autoescape: The Environment object is now created with autoescape=select_autoescape(['html', 'xml']). This ensures that Jinja2 automatically escapes any potentially dangerous HTML or XML content within the templates, preventing XSS vulnerabilities.

## Import: The select_autoescape function is imported from jinja2.

## Explanation:

select_autoescape(['html', 'xml']) is a Jinja2 function that automatically enables autoescaping for HTML and XML content. This means that any user-provided input within the templates will be automatically escaped, preventing XSS attacks.

## Additional Notes:

* The code now adheres to the best practices for using Jinja2 templates, ensuring that your application is more secure.

* You can further customize the select_autoescape function to include other content types if needed. Always review the documentation for the libraries you use to ensure you are using them securely.

By making these changes, you have addressed the potential XSS vulnerability in your code and made your application more secure.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Imported `select_autoescape` from Jinja2 to enhance security.
- Updated the `Environment` object creation to include `autoescape=select_autoescape(['html', 'xml'])`, ensuring that Jinja2 automatically escapes any potentially dangerous HTML or XML content within the templates.
- These changes address potential XSS vulnerabilities and adhere to best practices for using Jinja2 templates.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptBuilder.py</strong><dd><code>Enable autoescaping in Jinja2 environment to prevent XSS </code><br><code>vulnerabilities</code></dd></summary>
<hr>
      
cover_agent/PromptBuilder.py

<li>Imported <code>select_autoescape</code> from Jinja2.<br> <li> Updated <code>Environment</code> creation to include <br><code>autoescape=select_autoescape(['html', 'xml'])</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/51/files#diff-1602223755506d62450bdc4cea9140b0a11ccf93f7cd00151970cd1d649786ad">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

