### PR TITLE
fix get file base name error in   when the operating system is Windows #96

### DIFF
--- a/cover_agent/PromptBuilder.py
+++ b/cover_agent/PromptBuilder.py
@@ -1,6 +1,8 @@
 import logging
+import os
 
 from jinja2 import Environment, StrictUndefined
+
 from cover_agent.settings.config_loader import get_settings
 
 MAX_TESTS_PER_RUN = 4
@@ -31,7 +33,6 @@ Below is a list of failed tests that you generated in previous iterations. Do no
 
 
 class PromptBuilder:
-
     def __init__(
         self,
         source_file_path: str,
@@ -65,8 +66,8 @@ class PromptBuilder:
             build_prompt(self)
                 Replaces placeholders with the actual content of files read during initialization and returns the formatted prompt string.
         """
-        self.source_file_name = source_file_path.split("/")[-1]
-        self.test_file_name = test_file_path.split("/")[-1]
+        self.source_file_name = os.path.basename(source_file_path)
+        self.test_file_name = os.path.basename(test_file_path)
         self.source_file = self._read_file(source_file_path)
         self.test_file = self._read_file(test_file_path)
         self.code_coverage_report = code_coverage_report


### PR DESCRIPTION
### **User description**
fix bug in #96


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in `PromptBuilder` where file base names were incorrectly extracted using string splitting, which caused issues on Windows. Now using `os.path.basename` for compatibility across operating systems.
- Added import for `os` module to support the new method of extracting file base names.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptBuilder.py</strong><dd><code>Fix file base name extraction for Windows compatibility.</code>&nbsp; </dd></summary>
<hr>
      
cover_agent/PromptBuilder.py

<li>Import <code>os</code> module for path operations.<br> <li> Replace string splitting with <code>os.path.basename</code> to get file base names.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/97/files#diff-1602223755506d62450bdc4cea9140b0a11ccf93f7cd00151970cd1d649786ad">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

