### PR TITLE
Improved typing and minor fix in yaml utils methods

### DIFF
--- a/cover_agent/utils.py
+++ b/cover_agent/utils.py
@@ -37,7 +37,7 @@ def load_yaml(response_text: str, keys_fix_yaml: Optional[List[str]] = None) -> 
         if not data:
             logging.info("Failed to parse AI prediction after fixing YAML formatting.")
             raise Exception(
-                "Failed to parse AI prediction after fixing YAML formatting. Error: {e}."
+                "Failed to parse AI prediction after fixing YAML formatting."
             )
     return data
 


### PR DESCRIPTION
### **User Description**
- Changed default args to None, mutable defaults like lists are not recommend in python as they are stateful in subsequent calls.
- Removed some f strings where the string was static.
- `load_yaml` had a path which could have returned None, causing the dict read after that step to raise an exception, I've added an explicit exception in `load_yaml` in case `try_fix_yaml` fails as well.

___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `from __future__ import annotations` for forward compatibility.
- Changed `keys_fix_yaml` parameter type from `List[str]` to `Optional[List[str]]` in `load_yaml` and `try_fix_yaml` functions.
- Added checks for `None` and defaulted `keys_fix_yaml` to an empty list if not provided.
- Improved error handling by raising an exception when YAML parsing fails after attempting to fix formatting.
- Removed redundant f-strings in logging statements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Improved typing, error handling, and logging in YAML utility methods.</code></dd></summary>
<hr>
      
cover_agent/utils.py

<li>Added <code>from __future__ import annotations</code> for forward compatibility.<br> <li> Changed <code>keys_fix_yaml</code> parameter type from <code>List[str]</code> to <br><code>Optional[List[str]]</code> in <code>load_yaml</code> and <code>try_fix_yaml</code> functions.<br> <li> Added checks for <code>None</code> and defaulted <code>keys_fix_yaml</code> to an empty list if <br>not provided.<br> <li> Improved error handling by raising an exception when YAML parsing <br>fails after attempting to fix formatting.<br> <li> Removed redundant f-strings in logging statements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/101/files#diff-4b68afa4ecc709b261a42ca40bfe986f4d150bf47184bdecdadc4954d434dcb0">+20/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

