### PR TITLE
fixed bug - additional instruction were given twice

### DIFF
--- a/cover_agent/settings/test_generation_prompt.toml
+++ b/cover_agent/settings/test_generation_prompt.toml
@@ -107,13 +107,6 @@ new_tests:
 
 Use block scalar('|') to format each YAML output.
 
-
-{%- if additional_instructions_text|trim  %}
-
-{{ additional_instructions_text|trim }}
-{% endif %}
-
-
 Response (should be a valid YAML, and nothing else):
 ```yaml
 """


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed redundant additional instructions text block in `test_generation_prompt.toml`.
- Simplified the template by eliminating unnecessary condition.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_generation_prompt.toml</strong><dd><code>Remove duplicate additional instructions in test generation prompt</code></dd></summary>
<hr>

cover_agent/settings/test_generation_prompt.toml

<li>Removed redundant additional instructions text block.<br> <li> Simplified the template by eliminating unnecessary condition.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/148/files#diff-760e793bfd5f739e4369c90b8347a1af81c1a2b57f9b7ce2487379fc18b0b926">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

