### PR TITLE
Nightly Integration Tests: Upgrade Deprecated Action Versions

### DIFF
--- a/.github/workflows/nightly_regression.yml
+++ b/.github/workflows/nightly_regression.yml
@@ -12,15 +12,15 @@ jobs:
   build-executable:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     
     # Step to cache Poetry dependencies
     - name: Cache Poetry dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/pypoetry
@@ -36,7 +36,7 @@ jobs:
     - name: Build Executable
       run: make installer
     - name: Upload Executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cover-agent
         path: dist/cover-agent*
@@ -54,11 +54,11 @@ jobs:
     steps:
     # Step 1: Check out the repository code
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Step 2: Download the artifact
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cover-agent
         path: dist/


### PR DESCRIPTION
### **User description**
**Issue:**

The _nightly_regression.yml_ workflow named _Nightly Integration Tests_ raises multiple deprecation warnings due to outdated GitHub Actions.

**Solution:**

Upgrade the GitHub Actions in the workflow to their latest stable versions.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Upgraded multiple GitHub Actions to their latest stable versions in the `nightly_regression.yml` workflow.
- Addressed deprecation warnings by updating action versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nightly_regression.yml</strong><dd><code>Upgrade GitHub Actions to latest stable versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/nightly_regression.yml

<li>Upgraded <code>actions/checkout</code> from v2 to v4.<br> <li> Upgraded <code>actions/setup-python</code> from v2 to v5.<br> <li> Upgraded <code>actions/cache</code> from v2 to v4.<br> <li> Upgraded <code>actions/upload-artifact</code> from v3 to v4.<br> <li> Upgraded <code>actions/download-artifact</code> from v3 to v4.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/193/files#diff-e974b1b32761ee29d6423466ff4719774ec11424682ce151ceb184b96b56ccc5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information