### PR TITLE
Refactor UnitTestValidator to remove duplication of handling report from CoverageProcessing

### DIFF
--- a/cover_agent/UnitTestValidator.py
+++ b/cover_agent/UnitTestValidator.py
@@ -563,11 +563,11 @@ class UnitTestValidator:
                 for key in new_coverage_percentages:
                     if new_coverage_percentages[key] > self.last_coverage_percentages[key] and key == self.source_file_path.split("/")[-1]:
                         self.logger.info(
-                            f"Coverage for provided source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(coverage_percentages[key] * 100, 2)}"
+                            f"Coverage for provided source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(new_coverage_percentages[key] * 100, 2)}"
                         )
                     elif new_coverage_percentages[key] > self.last_coverage_percentages[key]:
                         self.logger.info(
-                            f"Coverage for non-source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(coverage_percentages[key] * 100, 2)}"
+                            f"Coverage for non-source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(new_coverage_percentages[key] * 100, 2)}"
                         )
                 self.current_coverage = new_percentage_covered
                 self.last_coverage_percentages = new_coverage_percentages.copy()


### PR DESCRIPTION
### **User description**
Code to run tests and process coverage report  is duplicated
  between `run_coverage` and `validate_test`. While the code in
  `run_coverage` is initializing `last_coverage_percentages`
  during initialization, the code in `validate_test` is updating
  the coverage percentages after adding generated tests.

  This PR attempts to just combine the handling of Union(Tuple, dict)
  from CoverageProcessor as it return Union(Tuple, dict).


___

### **PR Type**
enhancement


___

### **Description**
- Refactored the `UnitTestValidator` class to eliminate duplicate code for handling coverage reports.
- Introduced a new method `post_process_coverage_report` to centralize the logic for processing coverage reports.
- Initialized the `CoverageProcessor` during the class construction to streamline its usage across methods.
- Simplified the logic for updating coverage percentages in the `validate_test` method, improving code maintainability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UnitTestValidator.py</strong><dd><code>Refactor and unify coverage report processing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/UnitTestValidator.py

<li>Refactored to remove duplicate code for coverage processing.<br> <li> Introduced <code>post_process_coverage_report</code> method for unified coverage <br>handling.<br> <li> Initialized <code>CoverageProcessor</code> in the constructor.<br> <li> Simplified coverage percentage updates in <code>validate_test</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/209/files#diff-8e82655eb4312e27ba8b876368f619bb3fe73990d9c0ef379959a2b210141252">+66/-97</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information