### PR TITLE
[Fix] Added support for parsing reports in Kotlin language.

### DIFF
--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -212,7 +212,7 @@ class CoverageProcessor:
         """
         lines_covered, lines_missed = [], []
 
-        package_name, class_name = self.extract_package_and_class_java()
+        package_name, class_name = self.extract_package_and_class_java_kotlin()
         file_extension = self.get_file_extension(self.file_path)
 
         missed, covered = 0, 0
@@ -238,7 +238,7 @@ class CoverageProcessor:
         """Parses a JaCoCo XML code coverage report to extract covered and missed line numbers for a specific file."""
         tree = ET.parse(self.file_path)
         root = tree.getroot()
-        sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']")
+        sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']") or root.find(f".//sourcefile[@name='{class_name}.kt']")
 
         if sourcefile is None:
             return 0, 0
@@ -270,9 +270,9 @@ class CoverageProcessor:
 
         return missed, covered
 
-    def extract_package_and_class_java(self):
-        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;.*$")
-        class_pattern = re.compile(r"^\s*public\s+class\s+(\w+).*")
+    def extract_package_and_class_java_kotlin(self):
+        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;?$")
+        class_pattern = re.compile(r"^\s*(?:public\s+)?class\s+(\w+).*")
 
         package_name = ""
         class_name = ""

--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -240,6 +240,7 @@ class CoverageProcessor:
         root = tree.getroot()
         sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']") or root.find(f".//sourcefile[@name='{class_name}.kt']")
 
+
         if sourcefile is None:
             return 0, 0
 
@@ -265,14 +266,15 @@ class CoverageProcessor:
                         covered = int(row["LINE_COVERED"])
                         break
                     except KeyError as e:
-                        self.logger.error("Missing expected column in CSV: {e}")
+                        self.logger.error(f"Missing expected column in CSV: {str(e)}")
                         raise
 
         return missed, covered
 
     def extract_package_and_class_java_kotlin(self):
-        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;?$")
+        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)(?:\s*;)?\s*$")
         class_pattern = re.compile(r"^\s*(?:public\s+)?class\s+(\w+).*")
+
 
         package_name = ""
         class_name = ""


### PR DESCRIPTION
### **User description**
1. Added method for extracting `package` and `classname` for Kotlin language.
2. Added support for parsing JaCoCo XML format reports for Kotlin language.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the `CoverageProcessor` to support parsing JaCoCo XML reports for Kotlin language.
- Modified the method to extract `package` and `classname` to handle Kotlin syntax.
- Updated XML parsing logic to include Kotlin source files (`.kt`).
- Renamed the method `extract_package_and_class_java` to `extract_package_and_class_java_kotlin` to reflect its broader functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoverageProcessor.py</strong><dd><code>Add Kotlin support for JaCoCo XML report parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/CoverageProcessor.py

<li>Modified method to extract package and class names for Kotlin.<br> <li> Added support for <code>.kt</code> files in JaCoCo XML parsing.<br> <li> Renamed method to reflect support for both Java and Kotlin.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/220/files#diff-610c623a5c322b67c9a12fa75021723cc335d4dc3ce4676eb8576a20f3ffd93e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information