### PR TITLE
[Fix] Added support for parsing reports in Kotlin language.

### DIFF
--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -212,7 +212,7 @@ class CoverageProcessor:
         """
         lines_covered, lines_missed = [], []
 
-        package_name, class_name = self.extract_package_and_class_java()
+        package_name, class_name = self.extract_package_and_class_java_kotlin()
         file_extension = self.get_file_extension(self.file_path)
 
         missed, covered = 0, 0
@@ -238,7 +238,7 @@ class CoverageProcessor:
         """Parses a JaCoCo XML code coverage report to extract covered and missed line numbers for a specific file."""
         tree = ET.parse(self.file_path)
         root = tree.getroot()
-        sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']")
+        sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']") or root.find(f".//sourcefile[@name='{class_name}.kt']")
 
         if sourcefile is None:
             return 0, 0
@@ -270,9 +270,9 @@ class CoverageProcessor:
 
         return missed, covered
 
-    def extract_package_and_class_java(self):
-        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;.*$")
-        class_pattern = re.compile(r"^\s*public\s+class\s+(\w+).*")
+    def extract_package_and_class_java_kotlin(self):
+        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;?$")
+        class_pattern = re.compile(r"^\s*(?:public\s+)?class\s+(\w+).*")
 
         package_name = ""
         class_name = ""

--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -240,6 +240,7 @@ class CoverageProcessor:
         root = tree.getroot()
         sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']") or root.find(f".//sourcefile[@name='{class_name}.kt']")
 
+
         if sourcefile is None:
             return 0, 0
 
@@ -265,14 +266,15 @@ class CoverageProcessor:
                         covered = int(row["LINE_COVERED"])
                         break
                     except KeyError as e:
-                        self.logger.error("Missing expected column in CSV: {e}")
+                        self.logger.error(f"Missing expected column in CSV: {str(e)}")
                         raise
 
         return missed, covered
 
     def extract_package_and_class_java_kotlin(self):
-        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;?$")
+        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)(?:\s*;)?\s*$")
         class_pattern = re.compile(r"^\s*(?:public\s+)?class\s+(\w+).*")
+
 
         package_name = ""
         class_name = ""

--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -218,9 +218,9 @@ class CoverageProcessor:
             package_name, class_name = self.extract_package_and_class_java()
         elif source_file_extension == 'kt':
             package_name, class_name = self.extract_package_and_class_kotlin()
-
         else:
-            raise ValueError(f"Unsupported Byte Class Language: {source_file_extension}")
+            self.logger.warn(f"Unsupported Bytecode Language: {source_file_extension}. Using default Java logic.")
+            package_name, class_name = self.extract_package_and_class_java()
 
 
         file_extension = self.get_file_extension(self.file_path)

--- a/cover_agent/CoverageProcessor.py
+++ b/cover_agent/CoverageProcessor.py
@@ -211,8 +211,18 @@ class CoverageProcessor:
         total coverage percentage is returned to be evaluated only.
         """
         lines_covered, lines_missed = [], []
+        source_file_extension = self.get_file_extension(self.src_file_path)
 
-        package_name, class_name = self.extract_package_and_class_java_kotlin()
+        package_name, class_name = "",""
+        if source_file_extension == 'java':
+            package_name, class_name = self.extract_package_and_class_java()
+        elif source_file_extension == 'kt':
+            package_name, class_name = self.extract_package_and_class_kotlin()
+
+        else:
+            raise ValueError(f"Unsupported Byte Class Language: {source_file_extension}")
+
+
         file_extension = self.get_file_extension(self.file_path)
 
         missed, covered = 0, 0
@@ -238,8 +248,10 @@ class CoverageProcessor:
         """Parses a JaCoCo XML code coverage report to extract covered and missed line numbers for a specific file."""
         tree = ET.parse(self.file_path)
         root = tree.getroot()
-        sourcefile = root.find(f".//sourcefile[@name='{class_name}.java']") or root.find(f".//sourcefile[@name='{class_name}.kt']")
-
+        sourcefile = (
+                root.find(f".//sourcefile[@name='{class_name}.java']") or
+                root.find(f".//sourcefile[@name='{class_name}.kt']")
+        )
 
         if sourcefile is None:
             return 0, 0
@@ -271,10 +283,9 @@ class CoverageProcessor:
 
         return missed, covered
 
-    def extract_package_and_class_java_kotlin(self):
-        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)(?:\s*;)?\s*$")
-        class_pattern = re.compile(r"^\s*(?:public\s+)?class\s+(\w+).*")
-
+    def extract_package_and_class_java(self):
+        package_pattern = re.compile(r"^\s*package\s+([\w\.]+)\s*;.*$")
+        class_pattern = re.compile(r"^\s*public\s+class\s+(\w+).*")
 
         package_name = ""
         class_name = ""
@@ -298,7 +309,32 @@ class CoverageProcessor:
             raise
 
         return package_name, class_name
+    def extract_package_and_class_kotlin(self):
+        package_pattern = re.compile(r"^\s*package\s+([\w.]+)\s*(?:;)?\s*(?://.*)?$")
+        class_pattern = re.compile(r"^\s*(?:public|internal|abstract|data|sealed|enum|open|final|private|protected)*\s*class\s+(\w+).*")
 
+        package_name = ""
+        class_name = ""
+        try:
+            with open(self.src_file_path, "r") as file:
+                for line in file:
+                    if not package_name:  # Only match package if not already found
+                        package_match = package_pattern.match(line)
+                        if package_match:
+                            package_name = package_match.group(1)
+
+                    if not class_name:  # Only match class if not already found
+                        class_match = class_pattern.match(line)
+                        if class_match:
+                            class_name = class_match.group(1)
+
+                    if package_name and class_name:  # Exit loop if both are found
+                        break
+        except (FileNotFoundError, IOError) as e:
+            self.logger.error(f"Error reading file {self.src_file_path}: {e}")
+            raise
+
+        return package_name, class_name
 
     def parse_json_diff_coverage_report(self) -> Tuple[List[int], List[int], float]:
         """

--- a/tests/test_CoverageProcessor.py
+++ b/tests/test_CoverageProcessor.py
@@ -120,10 +120,39 @@ class TestCoverageProcessor:
         with pytest.raises(FileNotFoundError, match="File not found"):
             processor.extract_package_and_class_java()
 
+    def test_extract_package_and_class_kotlin(self, mocker):
+        kotlin_file_content = """
+        package com.madrapps.playground
+    
+        import androidx.lifecycle.ViewModel
+
+        class MainViewModel : ViewModel() {
+        
+            fun validate(userId: String): Boolean {
+                return userId == "admin"
+            }
+        
+            fun verifyAccess1(userId: String): Boolean {
+                return userId == "super-admin"
+            }
+        
+            fun verifyPassword(password: String): Boolean {
+                return password.isNotBlank()
+            }
+        }
+        """
+        mocker.patch("builtins.open", mocker.mock_open(read_data=kotlin_file_content))
+        processor = CoverageProcessor("fake_path", "path/to/MainViewModel.kt", "jacoco")
+        package_name, class_name = processor.extract_package_and_class_kotlin()
+        assert (
+            package_name == "com.madrapps.playground"
+        ), "Expected package name to be 'com.madrapps.playground'"
+        assert class_name == "MainViewModel", "Expected class name to be 'MainViewModel'"
+
     def test_extract_package_and_class_java(self, mocker):
         java_file_content = """
         package com.example;
-    
+
         public class MyClass {
             // class content
         }
@@ -132,7 +161,7 @@ class TestCoverageProcessor:
         processor = CoverageProcessor("fake_path", "path/to/MyClass.java", "jacoco")
         package_name, class_name = processor.extract_package_and_class_java()
         assert (
-            package_name == "com.example"
+                package_name == "com.example"
         ), "Expected package name to be 'com.example'"
         assert class_name == "MyClass", "Expected class name to be 'MyClass'"
 
@@ -327,6 +356,44 @@ class TestCoverageProcessor:
 
         processor = CoverageProcessor(
             "path/to/coverage_report.xml", "path/to/MyClass.java", "jacoco"
+        )
+
+        # Action
+        missed, covered = processor.parse_missed_covered_lines_jacoco_xml(
+            "MyClass"
+        )
+
+        # Assert
+        assert missed == 9
+        assert covered == 94
+
+    def test_parse_missed_covered_lines_kotlin_jacoco_xml(self, mocker):
+        #, mock_xml_tree
+        mocker.patch(
+            "cover_agent.CoverageProcessor.CoverageProcessor.extract_package_and_class_kotlin",
+            return_value=("com.example", "Example"),
+        )
+
+        xml_str = """<report>
+                        <package name="path/to">
+                            <sourcefile name="MyClass.kt">
+                                <counter type="INSTRUCTION" missed="53" covered="387"/>
+                                <counter type="BRANCH" missed="2" covered="6"/>
+                                <counter type="LINE" missed="9" covered="94"/>
+                                <counter type="COMPLEXITY" missed="5" covered="23"/>
+                                <counter type="METHOD" missed="3" covered="21"/>
+                                <counter type="CLASS" missed="0" covered="1"/>
+                            </sourcefile>
+                        </package>
+                    </report>"""
+
+        mocker.patch(
+            "xml.etree.ElementTree.parse",
+            return_value=ET.ElementTree(ET.fromstring(xml_str))
+        )
+
+        processor = CoverageProcessor(
+            "path/to/coverage_report.xml", "path/to/MyClass.kt", "jacoco"
         )
 
         # Action


### PR DESCRIPTION
### **User description**
1. Added method for extracting `package` and `classname` for Kotlin language.
2. Added support for parsing JaCoCo XML format reports for Kotlin language.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced the `CoverageProcessor` to support Kotlin language by modifying the method to extract package and class names.
- Added logic to handle `.kt` files in JaCoCo XML report parsing.
- Improved error logging for missing columns in CSV parsing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoverageProcessor.py</strong><dd><code>Add Kotlin support for JaCoCo XML report parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/CoverageProcessor.py

<li>Updated method to extract package and class names for Kotlin.<br> <li> Added support for parsing Kotlin files in JaCoCo XML reports.<br> <li> Improved error logging for missing CSV columns.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/221/files#diff-610c623a5c322b67c9a12fa75021723cc335d4dc3ce4676eb8576a20f3ffd93e">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information