### PR TITLE
Fixed Makefile to always include TOML files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Makefile
 SITE_PACKAGES=$(shell python -c "import wandb, os; print(os.path.dirname(wandb.__file__))")
+TOML_FILES=$(shell find cover_agent/settings -name "*.toml" | sed 's/.*/-\-add-data "&:."/' | tr '\n' ' ')
 
 .PHONY: test build installer
 
@@ -19,13 +20,7 @@ build:
 installer:
 	poetry run pyinstaller \
 		--add-data "cover_agent/version.txt:." \
-		--add-data "cover_agent/settings/analyze_suite_test_headers_indentation.toml:." \
-		--add-data "cover_agent/settings/analyze_suite_test_insert_line.toml:." \
-		--add-data "cover_agent/settings/analyze_test_against_context.toml:." \
-		--add-data "cover_agent/settings/analyze_test_run_failure.toml:." \
-		--add-data "cover_agent/settings/configuration.toml:." \
-		--add-data "cover_agent/settings/language_extensions.toml:." \
-		--add-data "cover_agent/settings/test_generation_prompt.toml:." \
+		$(TOML_FILES) \
 		--add-data "$(SITE_PACKAGES)/vendor:wandb/vendor" \
 		--hidden-import=tiktoken_ext.openai_public \
 		--hidden-import=tiktoken_ext \


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the Makefile to dynamically include all TOML files from the `cover_agent/settings` directory.
- Replaced hardcoded TOML file paths with a variable to improve maintainability and flexibility.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Dynamically include all TOML files in Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Added a variable <code>TOML_FILES</code> to dynamically find and include all TOML <br>files.<br> <li> Replaced hardcoded TOML file paths with the <code>TOML_FILES</code> variable in the <br><code>installer</code> target.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/cover-agent/pull/229/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information