### PR TITLE
Fix bug in main.py

### DIFF
--- a/cover_agent/main.py
+++ b/cover_agent/main.py
@@ -42,7 +42,7 @@ def parse_args(settings: Dynaconf) -> argparse.Namespace:
         (
             "--included-files",
             dict(
-                type=list,
+                type=str,
                 default=None,
                 nargs="*",
                 help=(


### PR DESCRIPTION
### **User description**
Fix bug in main.py. See #345


___

### **PR Type**
Bug fix


___

### **Description**
- Fix argument type for `--included-files` parameter

- Change from `list` to `str` type in argparse configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["--included-files argument"] -- "type change" --> B["list type"] -- "fixed to" --> C["str type"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Fix included-files argument type configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/main.py

<ul><li>Changed <code>--included-files</code> argument type from <code>list</code> to <code>str</code><br> <li> Fixed argparse configuration for proper argument parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/346/files#diff-610f77abc2025129e317ec1f98b3bb375b790b2197ed3f635331cca0a06fd999">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

